### PR TITLE
Fix pre commit action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: "black"
 
   - repo: "https://github.com/commitizen-tools/commitizen"
-    rev: "3.10.0"
+    rev: "v3.13.0"
     hooks:
       - id: "commitizen"
         stages: ["commit-msg"]


### PR DESCRIPTION
It looks like the old versions of the commitizen pre-commit hook had been removed, which was causing our github pre-commit action to fail. I updated it to the latest version and everything's working fine now.